### PR TITLE
fix ignoreRequest to be reset on every request

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -2,11 +2,11 @@ module.exports = function (options) {
   options = options ? options : {};
   let maxAge = options.maxAge ? options.maxAge : 86400;
   let includeSubDomains = options.includeSubDomains !== undefined ? options.includeSubdomains : true;
-  let ignoreRequest = (process.env.NODE_ENV !== "production");
 
   return function yes(req, res, next) {
+    let ignoreRequest = (process.env.NODE_ENV !== "production");
     let secure = req.connection.encrypted || (req.get('X-Forwarded-Proto') === "https");
-    
+
     if (options.ignoreFilter) {
       ignoreRequest = ignoreRequest || options.ignoreFilter(req);
     }


### PR DESCRIPTION
The definition of ignoreRequest should be done inside the `yes` function, so that it is initialized with each request. Otherwise, like with the current implementation, ignoreRequest will live over multiple requests. This causes any request to be ignored, after the first ignored request.

```
1. req http           -> redirect to https
2. req http (ignored) -> no redirect
3. req http           -> no redirect (ignoreRequest still is true)
```