### PR TITLE
fix: normalize includeSubDomains option handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,10 +41,14 @@ You can also set a few settings with the middleware to control the header:
 ```js
 app.use(yes({
   maxAge: 86400,            // defaults `86400`
-  includeSubdomains: true,  // defaults `true`
+  includeSubDomains: true,  // defaults `true`
   preload: true             // defaults `true`
 }));
 ```
+
+`includeSubDomains` is the canonical option name. For backwards
+compatibility, `includeSubdomains` is also accepted, and both spellings
+default to `true`.
 
 ### Ignoring specific requests
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -5,7 +5,7 @@ export default function (options) {
   options ||= {};
   const maxAge = options.maxAge || 86_400;
   const includeSubDomains =
-    options.includeSubDomains === undefined ? true : options.includeSubdomains;
+    options.includeSubDomains ?? options.includeSubdomains ?? true;
 
   return (request, response, next) => {
     let ignoreRequest = process.env.NODE_ENV !== 'production';

--- a/test/test.js
+++ b/test/test.js
@@ -54,6 +54,58 @@ describe('yes', () => {
       });
   }).timeout(60_000);
 
+  it('should allow disabling includeSubDomains with camel case options', (done) => {
+    const app = express();
+    app.use(
+      yes({
+        includeSubDomains: false,
+      }),
+    );
+    app.get('/test', (_request, response) => {
+      response.sendStatus(200);
+    });
+
+    const server = createSecureServer(app);
+    request('https://localhost:8443')
+      .get('/test')
+      .expect('Strict-Transport-Security', 'max-age=86400')
+      .expect(200)
+      .end((error) => {
+        if (error) {
+          throw error;
+        }
+
+        server.close();
+        done();
+      });
+  }).timeout(60_000);
+
+  it('should allow disabling includeSubDomains with the legacy lowercase alias', (done) => {
+    const app = express();
+    app.use(
+      yes({
+        includeSubdomains: false,
+      }),
+    );
+    app.get('/test', (_request, response) => {
+      response.sendStatus(200);
+    });
+
+    const server = createSecureServer(app);
+    request('https://localhost:8443')
+      .get('/test')
+      .expect('Strict-Transport-Security', 'max-age=86400')
+      .expect(200)
+      .end((error) => {
+        if (error) {
+          throw error;
+        }
+
+        server.close();
+        done();
+      });
+  }).timeout(60_000);
+
   it('should ignore filtered requests', (done) => {
     // Configure a minimal web server with the defaults
     const app = express();


### PR DESCRIPTION
## Summary
- preserve the default `includeSubDomains: true` behavior
- normalize option parsing so both `includeSubDomains` and `includeSubdomains` are accepted
- document the canonical option name and add regression tests for both spellings

## Testing
- npm test
- npm run lint

Closes #7