### PR TITLE
fix: limit renovate updates to major versions

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,9 +2,15 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended",
-    ":disableDependencyDashboard",
     ":enableVulnerabilityAlerts",
     ":configMigration",
     ":rebaseStalePrs"
+  ],
+  "dependencyDashboard": true,
+  "packageRules": [
+    {
+      "matchUpdateTypes": ["minor", "patch"],
+      "enabled": false
+    }
   ]
 }


### PR DESCRIPTION
## Summary
- stop Renovate from opening normal patch and minor update PRs
- re-enable the dependency dashboard for visibility into remaining updates

## Testing
- npm run renovate-config