### PR TITLE
chore: disable renovate dashboard issue

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -6,7 +6,7 @@
     ":configMigration",
     ":rebaseStalePrs"
   ],
-  "dependencyDashboard": true,
+  "dependencyDashboard": false,
   "packageRules": [
     {
       "matchUpdateTypes": ["minor", "patch"],


### PR DESCRIPTION
## Summary
- disable the Renovate dependency dashboard issue
- keep the rest of the Renovate configuration unchanged

## Testing
- not run (`npm run renovate-config` could not run because local dependencies are not installed in this worktree)