### PR TITLE
docs: add security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,39 @@
+# Security Policy
+
+## Supported Versions
+
+Security fixes are generally limited to the latest published release in the
+current major version line.
+
+| Version | Supported |
+| ------- | --------- |
+| 4.x     | Yes       |
+| < 4.0   | No        |
+
+This package supports Node.js 18 and later.
+
+## Reporting a Vulnerability
+
+Please do not report security vulnerabilities through public GitHub issues,
+pull requests, or discussions.
+
+Instead, report them privately by email to
+`justin.beckwith@gmail.com` with:
+
+- A clear description of the issue and its security impact
+- Steps to reproduce, proof of concept, or example requests
+- Affected package version, Node.js version, and deployment details
+- Any suggested mitigations or fixes, if you have them
+
+You can expect an initial response within 5 business days. After the report is
+reviewed, the maintainer will work with you on validation, remediation, and a
+coordinated disclosure timeline.
+
+Please keep vulnerability details private until a fix is available and users
+have had a reasonable opportunity to update.
+
+## Scope
+
+This policy applies to the `yes-https` package in this repository, including
+the published npm package and the source under active maintenance on the default
+branch.


### PR DESCRIPTION
## Summary
- add a `SECURITY.md` file at the repository root
- document supported versions for security fixes
- explain how to report vulnerabilities privately

## Testing
- not run (docs-only change)
