### PR TITLE
docs: use official badges in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@
 [![codecov](https://codecov.io/gh/JustinBeckwith/yes-https/branch/main/graph/badge.svg)](https://codecov.io/gh/JustinBeckwith/yes-https)
 [![npm version](https://badge.fury.io/js/yes-https.svg)](https://badge.fury.io/js/yes-https)
 [![Checked with Biome](https://img.shields.io/badge/Checked_with-Biome-60a5fa?style=flat&logo=biome)](https://biomejs.dev)
-[![Release](https://github.com/JustinBeckwith/yes-https/actions/workflows/release.yaml/badge.svg)](https://github.com/JustinBeckwith/yes-https/actions/workflows/release.yaml)
+
+Release automation by [release-please](https://github.com/googleapis/release-please).
 
 `yes-https` is a happy little npm module that makes it easy to require `https` for your connect based application.
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![codecov](https://codecov.io/gh/JustinBeckwith/yes-https/branch/main/graph/badge.svg)](https://codecov.io/gh/JustinBeckwith/yes-https)
 [![npm version](https://badge.fury.io/js/yes-https.svg)](https://badge.fury.io/js/yes-https)
 [![Checked with Biome](https://img.shields.io/badge/Checked_with-Biome-60a5fa?style=flat&logo=biome)](https://biomejs.dev)
-[![Release Please](https://img.shields.io/badge/Release%20automation-release--please-4285f4?style=flat)](https://github.com/googleapis/release-please)
+[![Release Please](https://img.shields.io/badge/%E2%9A%99%EF%B8%8F-release--please-4285f4?style=flat)](https://github.com/googleapis/release-please)
 
 `yes-https` is a happy little npm module that makes it easy to require `https` for your connect based application.
 

--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 [![Build Status](https://github.com/JustinBeckwith/yes-https/workflows/ci/badge.svg)](https://github.com/JustinBeckwith/yes-https/actions/)
 [![codecov](https://codecov.io/gh/JustinBeckwith/yes-https/branch/main/graph/badge.svg)](https://codecov.io/gh/JustinBeckwith/yes-https)
 [![npm version](https://badge.fury.io/js/yes-https.svg)](https://badge.fury.io/js/yes-https)
-[![Checked with Biome](https://img.shields.io/badge/checked_with-Biome-60a5fa.svg)](https://biomejs.dev)
-[![Release Please](https://img.shields.io/badge/release--please-enabled-4285f4.svg)](https://github.com/googleapis/release-please)
+[![Checked with Biome](https://img.shields.io/badge/Checked_with-Biome-60a5fa?style=flat&logo=biome)](https://biomejs.dev)
+[![Release](https://github.com/JustinBeckwith/yes-https/actions/workflows/release.yaml/badge.svg)](https://github.com/JustinBeckwith/yes-https/actions/workflows/release.yaml)
 
 `yes-https` is a happy little npm module that makes it easy to require `https` for your connect based application.
 

--- a/README.md
+++ b/README.md
@@ -4,8 +4,7 @@
 [![codecov](https://codecov.io/gh/JustinBeckwith/yes-https/branch/main/graph/badge.svg)](https://codecov.io/gh/JustinBeckwith/yes-https)
 [![npm version](https://badge.fury.io/js/yes-https.svg)](https://badge.fury.io/js/yes-https)
 [![Checked with Biome](https://img.shields.io/badge/Checked_with-Biome-60a5fa?style=flat&logo=biome)](https://biomejs.dev)
-
-Release automation by [release-please](https://github.com/googleapis/release-please).
+[![Release Please](https://img.shields.io/badge/Release%20automation-release--please-4285f4?style=flat)](https://github.com/googleapis/release-please)
 
 `yes-https` is a happy little npm module that makes it easy to require `https` for your connect based application.
 


### PR DESCRIPTION
## Summary
- replace the custom Biome badge with Biome's documented badge markup
- replace the custom release-please badge with the GitHub Actions workflow badge for the release workflow

## Testing
- not run (README-only change)