### PR TITLE
docs: use explicit CI workflow badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # YES HTTPS!
 
-[![Build Status](https://github.com/JustinBeckwith/yes-https/workflows/ci/badge.svg)](https://github.com/JustinBeckwith/yes-https/actions/)
+[![Build Status](https://github.com/JustinBeckwith/yes-https/actions/workflows/ci.yaml/badge.svg?branch=main)](https://github.com/JustinBeckwith/yes-https/actions/workflows/ci.yaml?query=branch%3Amain)
 [![codecov](https://codecov.io/gh/JustinBeckwith/yes-https/branch/main/graph/badge.svg)](https://codecov.io/gh/JustinBeckwith/yes-https)
 [![npm version](https://badge.fury.io/js/yes-https.svg)](https://badge.fury.io/js/yes-https)
 [![Checked with Biome](https://img.shields.io/badge/checked_with-Biome-60a5fa.svg)](https://biomejs.dev)


### PR DESCRIPTION
## Summary
- switch the README CI badge to the explicit  workflow badge URL
- pin the badge and link to the  branch CI workflow page

## Why
The existing badge used GitHub's legacy workflow-name endpoint, which can drift from the actual workflow status. This change makes the badge reflect the  workflow on  more reliably.