### PR TITLE
fix: pass GitHub token to npm publish

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -47,3 +47,5 @@ jobs:
       - run: npm ci
       - run: npm test
       - run: npm publish --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- pass \ to the \ step as \
- align yes-https with the working Trusted Publishing pattern used in linkinator
- preserve existing provenance-based publish flow

## Notes
- this is intended to unblock the next release created by release-please
- the previously created GitHub releases for 4.0.0 and 4.0.1 were not published to npm