### PR TITLE
fix: normalize repository metadata for npm publishing

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,10 +11,7 @@
     "fix": "biome check --write .",
     "coverage": "NODE_ENV=production node --test --experimental-test-coverage --test-reporter=spec --test-reporter-destination=stdout --test-reporter=lcov --test-reporter-destination=lcov.info"
   },
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/JustinBeckwith/yes-https.git"
-  },
+  "repository": "JustinBeckwith/yes-https",
   "keywords": [
     "hsts",
     "https"


### PR DESCRIPTION
## Summary
- simplify the package repository metadata to the GitHub shorthand form
- align yes-https with the working metadata pattern used in linkinator
- keep the change scoped to package metadata only

## Testing
- npm test