### PR TITLE
fix: use node 24 for release publishing

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,7 +10,7 @@ concurrency:
   cancel-in-progress: false
 env:
   FORCE_COLOR: 2
-  NODE: 22
+  NODE: 24
 jobs:
   release-please:
     if: github.repository == 'JustinBeckwith/yes-https'


### PR DESCRIPTION
## Summary
- bump the release workflow runtime from Node 22 to Node 24
- align the publish job with the current Node/npm baseline used by npm Trusted Publishing docs
- keep the change scoped to the release workflow only

## Testing
- npm test