### PR TITLE
feat!: drop support for old Node.js versions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,7 +15,7 @@ jobs:
     timeout-minutes: 15
     strategy:
       matrix:
-        node: [18, 20, 22]
+        node: [22, 24]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -51,7 +51,7 @@ jobs:
           files: ./lcov.info
           disable_search: true
           fail_ci_if_error: true
-          name: actions node 20
+          name: actions node 24
   lint:
     runs-on: ubuntu-latest
     timeout-minutes: 15

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,7 +10,7 @@ concurrency:
   cancel-in-progress: false
 env:
   FORCE_COLOR: 2
-  NODE: 22
+  NODE: 24
 jobs:
   release-please:
     if: github.repository == 'JustinBeckwith/yes-https'

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "supertest": "^7.0.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=22"
       }
     },
     "node_modules/@arcanis/slice-ansi": {

--- a/package.json
+++ b/package.json
@@ -29,6 +29,6 @@
     "supertest": "^7.0.0"
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=22"
   }
 }


### PR DESCRIPTION
## Summary
- require Node.js 22 or newer via package engines
- update CI to test Node.js 22 and 24
- publish releases on Node.js 24

## Breaking Change
- Node.js 18 and 20 are no longer supported.

## Testing
- npm test
- npm run lint